### PR TITLE
Add disc, year, album artist, and composer tags

### DIFF
--- a/lib/src/id3_tag.dart
+++ b/lib/src/id3_tag.dart
@@ -33,6 +33,8 @@ class ID3Tag {
 
   String? get composer => frameWithTypeAndName<TextInformation>('TCOM')?.value;
 
+  String? get genre => frameWithTypeAndName<TextInformation>('TCON')?.value;
+
   Duration? get duration {
     final durationRaw = frameWithTypeAndName<TextInformation>('TLEN')?.value;
     return durationRaw != null && durationRaw.isNotEmpty ? Duration(milliseconds: int.parse(durationRaw)) : null;

--- a/lib/src/id3_tag.dart
+++ b/lib/src/id3_tag.dart
@@ -24,6 +24,12 @@ class ID3Tag {
   String? get trackNumber => track?.split('/').firstIfAny(minLength: 2);
   String? get trackTotal => track?.split('/').lastIfAny(minLength: 2);
 
+  String? get disc => frameWithTypeAndName<TextInformation>('TPOS')?.value;
+  String? get discNumber => disc?.split('/').firstIfAny(minLength: 2);
+  String? get discTotal => disc?.split('/').lastIfAny(minLength: 2);
+
+  String? get year => frameWithTypeAndName<TextInformation>('TYER')?.value;
+
   Duration? get duration {
     final durationRaw = frameWithTypeAndName<TextInformation>('TLEN')?.value;
     return durationRaw != null && durationRaw.isNotEmpty ? Duration(milliseconds: int.parse(durationRaw)) : null;

--- a/lib/src/id3_tag.dart
+++ b/lib/src/id3_tag.dart
@@ -17,6 +17,7 @@ class ID3Tag {
   String? get title => frameWithTypeAndName<TextInformation>('TIT2')?.value;
 
   String? get artist => frameWithTypeAndName<TextInformation>('TPE1')?.value;
+  String? get albumArtist => frameWithTypeAndName<TextInformation>('TPE2')?.value;
 
   String? get album => frameWithTypeAndName<TextInformation>('TALB')?.value;
 
@@ -29,6 +30,8 @@ class ID3Tag {
   String? get discTotal => disc?.split('/').lastIfAny(minLength: 2);
 
   String? get year => frameWithTypeAndName<TextInformation>('TYER')?.value;
+
+  String? get composer => frameWithTypeAndName<TextInformation>('TCOM')?.value;
 
   Duration? get duration {
     final durationRaw = frameWithTypeAndName<TextInformation>('TLEN')?.value;


### PR DESCRIPTION
This PR adds the disc and year tags for the ID3Tag class. It's a very easy and straightforward implementation, and works well from what I've tried.

The tests should be modified to include this too, of course. This would fix #5.