### PR TITLE
Chapter timetsamps are not safe scan. This Fixes #8

### DIFF
--- a/lib/src/frame_body.dart
+++ b/lib/src/frame_body.dart
@@ -134,7 +134,10 @@ class FrameBody {
   int readInt() {
     return readBytes(4).parseInt(tagMinorVersion);
   }
-
+  int readIntRaw() {
+    return readBytes(4).parseInt(-1);// force non safescan
+  }
+  
   List<int> readRemainingBytes() {
     return buffer.sublist(pos);
   }

--- a/lib/src/frames/chapter_frame.dart
+++ b/lib/src/frames/chapter_frame.dart
@@ -48,10 +48,11 @@ class ChapterFrameParser extends FrameParser<Chapter> {
     final frameContent = rawFrame.frameContent;
     final elementId = frameContent.readString(checkEncoding: false);
 
-    final int startTimeMilliseconds = frameContent.readInt();
-    final int endTimeMilliseconds = frameContent.readInt();
-    /*final int startByteOffset =*/ frameContent.readInt();
-    /*final int endByteOffset =*/ frameContent.readInt();
+    // Following four ints are not safe scan according to ID3v2.4
+    final int startTimeMilliseconds = frameContent.readIntRaw();
+    final int endTimeMilliseconds = frameContent.readIntRaw();
+    /*final int startByteOffset =*/ frameContent.readIntRaw();
+    /*final int endByteOffset =*/ frameContent.readIntRaw();
 
     String? chapterName;
     String? chapterDescription;


### PR DESCRIPTION
Chapter timetsamps are not safe scan. This Fixes #8 .

Verified using yt-dlp --embed-chapters . This fix shows correct timestamps in app.

<img width="316" alt="image" src="https://github.com/user-attachments/assets/9a56889a-b47a-47e1-8953-0b6d459554ac">
